### PR TITLE
Fix #43 Made router.generate() safe

### DIFF
--- a/constants/ROUTER.js
+++ b/constants/ROUTER.js
@@ -7,4 +7,12 @@ const router = uniloc(mapValues(ROUTES, (route) => {
   return route.path;
 }));
 
-export default router;
+const generate = (name, options) => {
+  const safeName = ROUTES.hasOwnProperty(name) ? name : 'notFound';
+  return router.generate(safeName, options);
+};
+
+export default {
+  lookup: router.lookup,
+  generate: generate
+};

--- a/constants/ROUTES.js
+++ b/constants/ROUTES.js
@@ -1,5 +1,6 @@
 import Home from 'components/Home.jsx';
 import DatesApp from 'components/DatesApp.jsx';
+import NotFound from 'components/NotFound.jsx';
 
 const route = (text, path, component) => {
   return { text, path, component };
@@ -7,7 +8,8 @@ const route = (text, path, component) => {
 
 const ROUTES = {
   home: route('Home', 'GET /home', Home),
-  dates: route('Dates', 'GET /dates', DatesApp)
+  dates: route('Dates', 'GET /dates', DatesApp),
+  notFound: route('Not Found', 'GET /404', NotFound)
 };
 
 export default ROUTES;


### PR DESCRIPTION
If the navigation reducer had undefined for the current route name, that would get sent down to the Link component, which would try to generate a URL with it. Then uniloc would throw an exception.

I wrapped the uniloc generate() function to safely return the 404 page.
